### PR TITLE
feature/PPAA-36 make logger optional + different loggers

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "chokidar": "^3.5.2",
     "lodash": "^4.17.15",
-    "uuid": "^8.3.2",
-    "rule-harvester": "file:.."
+    "rule-harvester": "file:..",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rule-harvester",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "RuleHarvester is a rules engine for javascript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,15 +19,17 @@
     "test": "mocha -r ts-node/register ./tests/**/*.test.ts"
   },
   "dependencies": {
+    "amqp-cacoon": "^3.0.3",
+    "coronado-bridge": "^2.0.0",
     "lodash": "^4.17.21",
     "log4js": "^6.3.0",
-    "rules-js": "^1.0.0",
-    "amqp-cacoon": "^3.0.3",
-    "coronado-bridge": "^2.0.0"
+    "rules-js": "^1.0.0"
   },
   "author": "Valtech: Daniel Morris",
   "license": "MIT",
   "devDependencies": {
+    "@types/amqp-connection-manager": "^2.0.12",
+    "@types/amqplib": "^0.8.2",
     "@types/chai": "^4.2.21",
     "@types/lodash": "^4.14.172",
     "@types/mocha": "^9.0.0",
@@ -39,9 +41,7 @@
     "sinon": "^11.1.2",
     "ts-node": "^10.2.1",
     "ts-sinon": "^2.0.1",
-    "typescript": "^4.3.5",
-    "@types/amqp-connection-manager": "^2.0.12",
-    "@types/amqplib": "^0.8.2"
+    "typescript": "^4.3.5"
   },
   "publishConfig": {
     "access": "public"

--- a/src/core/inputs/amqp-input.ts
+++ b/src/core/inputs/amqp-input.ts
@@ -1,11 +1,10 @@
-import { IInputProvider } from '../../types';
+import { IInputProvider, ILogger } from '../../types';
 import { ICoreAmqpMessage } from '../types/amqp-types';
 import AmqpCacoon, {
   ConsumeMessage,
   Channel,
   ChannelWrapper,
 } from 'amqp-cacoon';
-import { Logger } from 'log4js';
 import _ from 'lodash';
 import { default as util } from 'util';
 
@@ -28,7 +27,7 @@ export interface ICoreInputAmqpProviderOptions {
 export default class CoreInputAmqp implements IInputProvider {
   private handler!: (input: any, context: any) => Promise<any>;
   private alreadyRegistered: boolean;
-  private logger?: Logger;
+  private logger?: ILogger;
   private amqpCacoon: AmqpCacoon;
   private amqpQueue: string;
   private options: ICoreInputAmqpProviderOptions;
@@ -46,7 +45,7 @@ export default class CoreInputAmqp implements IInputProvider {
   constructor(
     amqpCacoon: AmqpCacoon,
     amqpQueue: string,
-    logger: Logger | undefined,
+    logger: ILogger | undefined,
     options: ICoreInputAmqpProviderOptions
   ) {
     this.alreadyRegistered = false;

--- a/src/core/inputs/amqp-input.ts
+++ b/src/core/inputs/amqp-input.ts
@@ -28,7 +28,7 @@ export interface ICoreInputAmqpProviderOptions {
 export default class CoreInputAmqp implements IInputProvider {
   private handler!: (input: any, context: any) => Promise<any>;
   private alreadyRegistered: boolean;
-  private logger: Logger;
+  private logger?: Logger;
   private amqpCacoon: AmqpCacoon;
   private amqpQueue: string;
   private options: ICoreInputAmqpProviderOptions;
@@ -46,7 +46,7 @@ export default class CoreInputAmqp implements IInputProvider {
   constructor(
     amqpCacoon: AmqpCacoon,
     amqpQueue: string,
-    logger: Logger,
+    logger: Logger | undefined,
     options: ICoreInputAmqpProviderOptions
   ) {
     this.alreadyRegistered = false;
@@ -71,7 +71,7 @@ export default class CoreInputAmqp implements IInputProvider {
   async registerInput(
     applyInputCb: (input: any, context: any) => Promise<any>
   ) {
-    this.logger.trace(`CoreInputAmqp.registerHandler: Start`);
+    this.logger?.trace(`CoreInputAmqp.registerHandler: Start`);
 
     // Link applyInputCb to a class property we can reference later
     this.handler = applyInputCb;
@@ -85,7 +85,7 @@ export default class CoreInputAmqp implements IInputProvider {
       // Make so we only register one consumer
       this.alreadyRegistered = true;
     }
-    this.logger.trace(`CoreInputAmqp.registerHandler: End`);
+    this.logger?.trace(`CoreInputAmqp.registerHandler: End`);
   }
 
   /**
@@ -106,7 +106,7 @@ export default class CoreInputAmqp implements IInputProvider {
    * @return Promise<void>
    **/
   async amqpHandler(channel: ChannelWrapper, msg: ConsumeMessage) {
-    this.logger.trace(`CoreInputAmqp.amqpHandler: Start`);
+    this.logger?.trace(`CoreInputAmqp.amqpHandler: Start`);
     try {
       // Create an object for our message - note we DO NOT validate the message here at all!
       // It will be set to a string with whatever. it's the responsibility of the application
@@ -126,7 +126,7 @@ export default class CoreInputAmqp implements IInputProvider {
         context = _.merge(context, this.options.inputContextCallback(msg));
       }
 
-      this.logger.debug(
+      this.logger?.debug(
         `CoreInputAmqp.amqpHandler - amqpMessage: ${util.inspect(amqpMessage)}`
       );
 
@@ -150,14 +150,14 @@ export default class CoreInputAmqp implements IInputProvider {
       // to trigger this first condition! These messages, since they are invalid, are ACK so that they don't
       // requeue forever! (They're expected to fail any retry, since they're invalid!)
       if (e.name === 'MessageValidationError') {
-        this.logger.error(
+        this.logger?.error(
           `CoreInputAmqp.amqpHandler: Validation Error: ${e.message}`
         );
-        this.logger.trace(`The message contained: ${msg.content.toString()}`);
-        this.logger.trace(
+        this.logger?.trace(`The message contained: ${msg.content.toString()}`);
+        this.logger?.trace(
           `The message fields contained: ${util.inspect(msg.fields)}`
         );
-        this.logger.trace(
+        this.logger?.trace(
           `The message properties contained: ${util.inspect(msg.properties)}`
         );
         // Since we're dealing with INVALID messages (as defined by the application using this Input) we
@@ -165,7 +165,7 @@ export default class CoreInputAmqp implements IInputProvider {
         channel.ack(msg);
       } else {
         // Otherwise, the error is something other than INVALID MESSAGE, so we deal with it.
-        this.logger.error(
+        this.logger?.error(
           `CoreInputAmqp.amqpHandler - Will Nack Message - INNER ERROR: ${e.message}`
         );
         // TODO: Implement a requeueHandler callback - it will get the ORIGINAL message and context since
@@ -175,6 +175,6 @@ export default class CoreInputAmqp implements IInputProvider {
         channel.nack(msg, false, this.options.requeueOnNack || false);
       }
     }
-    this.logger.trace(`CoreInputAmqp.amqpHandler: End`);
+    this.logger?.trace(`CoreInputAmqp.amqpHandler: End`);
   }
 }

--- a/src/core/inputs/http-input.ts
+++ b/src/core/inputs/http-input.ts
@@ -40,7 +40,7 @@ export interface ICoreInputHttpProviderOptions {
 
 export default class CoreInputHttp implements IInputProvider {
   private alreadyRegistered: boolean;
-  private logger: Logger;
+  private logger?: Logger;
   private httpPorts: Array<number>;
   private httpBridge!: CoronadoBridge;
   private httpHandler!: any;
@@ -57,7 +57,7 @@ export default class CoreInputHttp implements IInputProvider {
    **/
   constructor(
     httpPorts: Array<number>,
-    logger: Logger,
+    logger: Logger | undefined,
     options: ICoreInputHttpProviderOptions
   ) {
     this.alreadyRegistered = false;
@@ -85,7 +85,7 @@ export default class CoreInputHttp implements IInputProvider {
   async registerInput(
     applyInputCb: (input: any, context: any) => Promise<any>
   ) {
-    this.logger.trace(`CoreInputHttp.registerHandler: Start`);
+    this.logger?.trace(`CoreInputHttp.registerHandler: Start`);
 
     // Setup a handler for the Http request
     this.httpHandler = new HttpHandler(applyInputCb, this.logger, this.options);
@@ -102,7 +102,7 @@ export default class CoreInputHttp implements IInputProvider {
       // Keep track so that we only register one http bridge
       this.alreadyRegistered = true;
     }
-    this.logger.trace(`CoreInputHttp.registerHandler: End`);
+    this.logger?.trace(`CoreInputHttp.registerHandler: End`);
   }
 
   async unregisterInput() {
@@ -130,13 +130,13 @@ export default class CoreInputHttp implements IInputProvider {
  */
 class HttpHandler implements IOutboundProvider {
   private applyInputCb;
-  private logger: Logger;
+  private logger?: Logger;
   private options: ICoreInputHttpProviderOptions;
 
   // Construct our instance, holding the reference to the Rule-Harvester Apply Input Callback
   constructor(
     applyInputCb: (input: any, context: any) => Promise<any>,
-    logger: Logger,
+    logger: Logger | undefined,
     options: ICoreInputHttpProviderOptions
   ) {
     this.applyInputCb = applyInputCb;
@@ -181,7 +181,7 @@ class HttpHandler implements IOutboundProvider {
    */
   async handler(req: ICoreHttpRequest) {
     // Trace out the request
-    this.logger.trace(req);
+    this.logger?.trace(req);
 
     // And an object for our context
     let context: any = {};
@@ -219,7 +219,7 @@ class HttpHandler implements IOutboundProvider {
       // Something threw. We pass it forward. If it's a BridgeError the bridge will
       // pass properly formatted to the http client! Otherwise, the bridge will return an http 500 with
       // ex.message.
-      this.logger.trace(
+      this.logger?.trace(
         `CoreInputHttp HttpHandler - Received error - ${ex.message}`
       );
       throw ex;
@@ -240,7 +240,7 @@ class HttpHandler implements IOutboundProvider {
     // engine might throw!
     const result = await this.applyInputCb({ httpRequest: req }, context);
     // Log the result
-    this.logger.trace(result);
+    this.logger?.trace(result);
     // Result (which is the entire altered facts object after a rules pass) can also contain
     // a property httpResponseAction in order to respond with something custom. If we find it
     // we respond wih that! If it's empty or just undefined, the http bridge will just respond

--- a/src/core/inputs/http-input.ts
+++ b/src/core/inputs/http-input.ts
@@ -8,7 +8,7 @@ import CoronadoBridge, {
 } from 'coronado-bridge';
 
 // Bring in rule-harvester dependencies
-import { IInputProvider } from '../../types';
+import { IInputProvider, ILogger } from '../../types';
 import { ICoreHttpRequest } from '../types/http-types';
 
 /**
@@ -40,7 +40,7 @@ export interface ICoreInputHttpProviderOptions {
 
 export default class CoreInputHttp implements IInputProvider {
   private alreadyRegistered: boolean;
-  private logger?: Logger;
+  private logger?: ILogger;
   private httpPorts: Array<number>;
   private httpBridge!: CoronadoBridge;
   private httpHandler!: any;
@@ -57,7 +57,7 @@ export default class CoreInputHttp implements IInputProvider {
    **/
   constructor(
     httpPorts: Array<number>,
-    logger: Logger | undefined,
+    logger: ILogger | undefined,
     options: ICoreInputHttpProviderOptions
   ) {
     this.alreadyRegistered = false;
@@ -95,7 +95,7 @@ export default class CoreInputHttp implements IInputProvider {
       // Configure then Start up a new instance of the Http Bridge (note, this wires in the handler!)
       const bridgeConfig: IBridgeConfig = {
         ports: this.httpPorts,
-        logger: this.logger,
+        logger: this.logger as Logger,
         outboundProvider: this.httpHandler,
       };
       this.httpBridge = new CoronadoBridge(bridgeConfig);
@@ -130,13 +130,13 @@ export default class CoreInputHttp implements IInputProvider {
  */
 class HttpHandler implements IOutboundProvider {
   private applyInputCb;
-  private logger?: Logger;
+  private logger?: ILogger;
   private options: ICoreInputHttpProviderOptions;
 
   // Construct our instance, holding the reference to the Rule-Harvester Apply Input Callback
   constructor(
     applyInputCb: (input: any, context: any) => Promise<any>,
-    logger: Logger | undefined,
+    logger: ILogger | undefined,
     options: ICoreInputHttpProviderOptions
   ) {
     this.applyInputCb = applyInputCb;

--- a/src/core/outputs/amqp-output.ts
+++ b/src/core/outputs/amqp-output.ts
@@ -20,7 +20,7 @@ import { default as util } from 'util';
  **/
 export default class CoreOutputAmqp implements IOutputProvider {
   private alreadyRegistered: boolean;
-  private logger: Logger;
+  private logger?: Logger;
   private amqpCacoon: AmqpCacoon;
   private amqpPublishChannelWrapper!: ChannelWrapper;
 
@@ -66,7 +66,7 @@ export default class CoreOutputAmqp implements IOutputProvider {
    * @returns Promise<void>
    **/
   async outputResult(result: IOutputResult) {
-    this.logger.trace(`CoreOutputAmqp.outputResult: Start`);
+    this.logger?.trace(`CoreOutputAmqp.outputResult: Start`);
 
     // Open our publish channel, but only if we've not already done it!
     if (!this.alreadyRegistered) {
@@ -81,7 +81,7 @@ export default class CoreOutputAmqp implements IOutputProvider {
     try {
       if (result.error) {
         // The rules engine already sent in an error, so we just log and not output
-        this.logger.error(
+        this.logger?.error(
           `CoreOutputAmqp.outputResult: the result object contained an error. Nothing will publish. The error received was: ${util.inspect(
             result.error
           )}`
@@ -117,23 +117,23 @@ export default class CoreOutputAmqp implements IOutputProvider {
             amqpPublishOptions
           );
           // Log success
-          this.logger.info(
+          this.logger?.info(
             `CoreOutputAmqp.outputResult: Message published to exchange='${amqpPublishExchange}' with routingKey='${amqpPublishRoutingKey}'.`
           );
         }
       } else {
         // We don't have an amqpPublishAction, so we log that.
-        this.logger.error(
+        this.logger?.error(
           `CoreOutputAmqp.outputResult: Error in retrieving an amqpPublishAction from result.facts. Nothing was published.`
         );
       }
     } catch (e) {
       // Oh no! Something else. Log the error.
-      this.logger.error(
+      this.logger?.error(
         `CoreOutputAmqp.outputResult: Error - INNER ERROR: ${e.message}`
       );
     }
 
-    this.logger.trace(`CoreOutputAmqp.outputResult: End`);
+    this.logger?.trace(`CoreOutputAmqp.outputResult: End`);
   }
 }

--- a/src/core/outputs/amqp-output.ts
+++ b/src/core/outputs/amqp-output.ts
@@ -1,9 +1,8 @@
-import { IOutputProvider, IOutputResult } from '../../types';
+import { ILogger, IOutputProvider, IOutputResult } from '../../types';
 import { ICoreAmqpPublishAction } from '../types/amqp-types';
 import AmqpCacoon, {
   ChannelWrapper,
 } from 'amqp-cacoon';
-import { Logger } from 'log4js';
 import _ from 'lodash';
 import { default as util } from 'util';
 
@@ -20,7 +19,7 @@ import { default as util } from 'util';
  **/
 export default class CoreOutputAmqp implements IOutputProvider {
   private alreadyRegistered: boolean;
-  private logger?: Logger;
+  private logger?: ILogger;
   private amqpCacoon: AmqpCacoon;
   private amqpPublishChannelWrapper!: ChannelWrapper;
 
@@ -32,7 +31,7 @@ export default class CoreOutputAmqp implements IOutputProvider {
    * @param amqpCacoon - an instance of AMQP Cacoon which will manage all AMQP communications.
    * @param logger - a log4js logger instance to use for logging.
    **/
-  constructor(amqpCacoon: AmqpCacoon, logger: Logger) {
+  constructor(amqpCacoon: AmqpCacoon, logger: ILogger) {
     this.alreadyRegistered = false;
     // Save the constructor parameters to local class variables
     this.logger = logger;

--- a/src/core/outputs/amqp-rpc-output.ts
+++ b/src/core/outputs/amqp-rpc-output.ts
@@ -1,7 +1,6 @@
-import { IOutputProvider, IOutputResult } from '../../types';
+import { ILogger, IOutputProvider, IOutputResult } from '../../types';
 import { ICoreAmqpRpcPublishAction } from '../types/amqp-types';
 import AmqpCacoon, { ChannelWrapper } from 'amqp-cacoon';
-import { Logger } from 'log4js';
 import _ from 'lodash';
 import { default as util } from 'util';
 
@@ -18,7 +17,7 @@ import { default as util } from 'util';
  **/
 export default class CoreOutputAmqpRpc implements IOutputProvider {
   private alreadyRegistered: boolean;
-  private logger?: Logger;
+  private logger?: ILogger;
   private amqpCacoon: AmqpCacoon;
   private amqpPublishChannelWrapper!: ChannelWrapper;
 
@@ -30,7 +29,7 @@ export default class CoreOutputAmqpRpc implements IOutputProvider {
    * @param amqpCacoon - an instance of AMQP Cacoon which will manage all AMQP communications.
    * @param logger - a log4js logger instance to use for logging.
    **/
-  constructor(amqpCacoon: AmqpCacoon, logger: Logger) {
+  constructor(amqpCacoon: AmqpCacoon, logger: ILogger) {
     this.alreadyRegistered = false;
     // Save the constructor parameters to local class variables
     this.logger = logger;

--- a/src/core/outputs/amqp-rpc-output.ts
+++ b/src/core/outputs/amqp-rpc-output.ts
@@ -18,7 +18,7 @@ import { default as util } from 'util';
  **/
 export default class CoreOutputAmqpRpc implements IOutputProvider {
   private alreadyRegistered: boolean;
-  private logger: Logger;
+  private logger?: Logger;
   private amqpCacoon: AmqpCacoon;
   private amqpPublishChannelWrapper!: ChannelWrapper;
 
@@ -64,7 +64,7 @@ export default class CoreOutputAmqpRpc implements IOutputProvider {
    * @returns Promise<void>
    **/
   async outputResult(result: IOutputResult) {
-    this.logger.trace(`CoreOutputAmqpRpc.outputResult: Start`);
+    this.logger?.trace(`CoreOutputAmqpRpc.outputResult: Start`);
 
     // Open our publish channel, but only if we've not already done it!
     if (!this.alreadyRegistered) {
@@ -79,7 +79,7 @@ export default class CoreOutputAmqpRpc implements IOutputProvider {
     try {
       if (result.error) {
         // The rules engine already sent in an error, so we just log and not output
-        this.logger.error(
+        this.logger?.error(
           `CoreOutputAmqpRpc.outputResult: the result object contained an error. Nothing will publish. The error received was: ${util.inspect(
             result.error
           )}`
@@ -120,12 +120,12 @@ export default class CoreOutputAmqpRpc implements IOutputProvider {
             { correlationId: correlationId }
           );
           // Log success
-          this.logger.info(
+          this.logger?.info(
             `CoreOutputAmqpRpc.outputResult: Message published to reply-to='${replyTo}'.`
           );
         } else {
           // We don't have a replyTo nor correlationId, so we log that.
-          this.logger.error(
+          this.logger?.error(
             `CoreOutputAmqpRpc.outputResult: Error in executing amqpRpcPublishAction from result.facts. The original message did not have the required properties "reply_to" and "correlation_id". Unable to respond via AMQP RPC.`
           );
         }
@@ -136,18 +136,18 @@ export default class CoreOutputAmqpRpc implements IOutputProvider {
         ) {
           // We have an amqpRpcPublishAction, but we can't retrieve the original amqpMessage.
           // This means we won't be able to respond since the original message is needed to know how to respond!
-          this.logger.error(
+          this.logger?.error(
             `CoreOutputAmqpRpc.outputResult: Error in retrieving the original amqpMessage for an amqpRpcPublishAction from result.facts. Nothing was published.`
           );
         }
       }
     } catch (e) {
       // Oh no! Something else. Log the error.
-      this.logger.error(
+      this.logger?.error(
         `CoreOutputAmqpRpc.outputResult: Error - INNER ERROR: ${e.message}`
       );
     }
 
-    this.logger.trace(`CoreOutputAmqpRpc.outputResult: End`);
+    this.logger?.trace(`CoreOutputAmqpRpc.outputResult: End`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,18 +4,18 @@ import {
   IOutputProvider,
   ICorpusRuleGroup,
   IClosure,
+  ILogger,
 } from './types';
 //@ts-ignore
 import Engine from 'rules-js';
 import _ from 'lodash';
-import { Logger } from 'log4js';
 
 export interface IRuleHarvesterProviders {
   inputs: IInputProvider[];
   outputs: IOutputProvider[];
   corpus: ICorpusRuleGroup[];
   closures: IClosure[];
-  logger?: Logger;
+  logger?: ILogger;
 }
 
 export interface IRuleHarvesterConfig {
@@ -67,7 +67,7 @@ export default class RuleHarvester {
   providers: IRuleHarvesterProviders;
   config: IRuleHarvesterConfig;
   engine: any;
-  logger?: Logger;
+  logger?: ILogger;
   fieldDereferenceChar: string = '^';
   ruleGroups: string[];
   extraContext?: object | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,3 +57,14 @@ export interface IClosure {
   rules?: ICorpusRule[];
   options?: object;
 }
+
+interface IAnyFunction {
+	(...args: any[]): any;
+}
+export interface ILogger {
+	debug: IAnyFunction;
+	error: IAnyFunction;
+	fatal: IAnyFunction;
+	info: IAnyFunction;
+	trace: IAnyFunction;
+}


### PR DESCRIPTION
# PPAA-36
**The objective is to make passing a logger as a parameter optional. And also, to have the flexibility to pass different loggers**

### For more details see
[PPAA-36](https://jira.valtech.com/browse/PPAA-26)

### Changes
- [x] `CoreInputAmqp`:  make `logger` an optional parameter
- [x] `CoreInputHttp`:  make `logger` an optional parameter.    
- [x] `CoreOutputAmqp`:  make `logger` an optional parameter.    
- [x] `CoreOutputAmqpRpc`:  make `logger` an optional parameter.    
- [x]  Change dependency on log4js for a dependency on an interface  

For a logger to work, it should have at least the following methods:

- debug
- error
- fatal
- info
- trace

Some loggers you may try with:
- [log4js](https://www.npmjs.com/package/log4js)
- [tslog](https://www.npmjs.com/package/tslog)
- <s>[winston](https://www.npmjs.com/package/winston)</s> (It doesn't have `fatal`, which is used [here]( https://github.com/valtech-sd/rule-harvester/blob/1c3e6b8c1e48684f3fa4d19c5514c5c99f0c2c64/src/index.ts#L337)
- [bunyan](https://www.npmjs.com/package/bunyan)

## How to test:
You should be able to instantiate any of the exported classes (passing a 'compatible'  logger as a parameter):
    -  RulesHarvester
    - CoreInputAmqp
    - CoreInputHttp
    - CoreOutputAmqp
    - CoreOutputAmqpRpc



For example, you can run the rule-harvester example passing different loggers to RulesHarvester [directory-watcher-input.js ](https://github.com/valtech-sd/rule-harvester/blob/master/examples/src/example-directory-watcher-input.js)

