### PR TITLE
PPAA-605 Ensure httpResponseAction passes instanceof OutboundResponse check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:14.18
+    - image: circleci/node:18.14.1
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:18.14.1
+    - image: cimg/node:18.14.1
 
 jobs:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "rule-harvester",
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {

--- a/src/core/inputs/http-input.ts
+++ b/src/core/inputs/http-input.ts
@@ -243,8 +243,9 @@ class HttpHandler implements IOutboundProvider {
     // Result (which is the entire altered facts object after a rules pass) can also contain
     // a property httpResponseAction in order to respond with something custom. If we find it
     // we respond wih that! If it's empty or just undefined, the http bridge will just respond
-    // with http 200 and an empty body!
-    return result.httpResponseAction;
+    // with http 200 and an empty body!  The http bridge will also always respond with 200 if
+    // this is not an instanceof OutboundResponse.
+    return new OutboundResponse(result.httpResponseAction.body, result.httpResponseAction.status, result.httpResponseAction.headers);
   }
 
   /**


### PR DESCRIPTION
[CoronadoBridge will always return status 200 if response is not instanceof OutboundResponse](https://github.com/valtech-sd/coronado-bridge/blob/master/src/bridge.ts#L116).

To ensure status codes are preserved for `ICoreHttpResponseAction` / `httpResponseAction` errors, we should make sure they are returned as as `OutboundResponse`.